### PR TITLE
Avoid showing the groupThreads on the graphs

### DIFF
--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/registry/MicrometerRegistry.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/registry/MicrometerRegistry.java
@@ -144,7 +144,7 @@ public class MicrometerRegistry {
 		// Create micrometer tags to feed with data
 		String threadTag = Util.makeMicrometerName(result.getThreadGroupLabel());
 		String samplerTag = "spl_"+Util.makeMicrometerName(result.getSamplerLabel());
-		List<String> micrometerTags = Arrays.asList(new String[]{threadTag, samplerTag, this.totalLabel});
+		List<String> micrometerTags = Arrays.asList(new String[]{samplerTag, this.totalLabel});
 		
 		for(String microMeterTag : micrometerTags) {
 			// Save current period responses time

--- a/ulp-observability-front/src/main/front/src/app/components/ulp-observability-chart/ulp-observability-chart.component.ts
+++ b/ulp-observability-front/src/main/front/src/app/components/ulp-observability-chart/ulp-observability-chart.component.ts
@@ -124,15 +124,15 @@ export class UlpObservabilityChartComponent implements OnChanges, OnInit {
       let curveLabel = entry[0]
 
       const isNotTotalLabel = curveLabel !== this.totalLabel;
-      const isNotTotalThreadsLabel = curveLabel !== this.totalLabel + '_threads';
-      const hasSplPrefix = curveLabel.startsWith('spl_');
+      const hasSamplerPrefix = curveLabel.startsWith('spl_');
       const hasThreadsSuffix = curveLabel.endsWith('_threads');
-      const isSplWithoutThreads = hasSplPrefix && !hasThreadsSuffix;
-      const isNotSplWithThreads = !hasSplPrefix && hasThreadsSuffix;
+      const isThreadGroup = hasSamplerPrefix && hasThreadsSuffix;
 
-      if(isNotTotalLabel && isNotTotalThreadsLabel && (isSplWithoutThreads || isNotSplWithThreads)){
-
-        if(hasSplPrefix){
+      if(isNotTotalLabel && !isThreadGroup) {
+        const isTotalThreadsLabel = curveLabel === this.totalLabel + '_threads';
+        curveLabel = isTotalThreadsLabel ? "total" + "_threads" : curveLabel;
+ 
+        if(hasSamplerPrefix){
           curveLabel = curveLabel.slice(curveLabel.indexOf('_')+1,curveLabel.length);
         }
         

--- a/ulp-observability-front/src/main/front/src/app/components/ulp-observability-chart/ulp-observability-chart.component.ts
+++ b/ulp-observability-front/src/main/front/src/app/components/ulp-observability-chart/ulp-observability-chart.component.ts
@@ -122,9 +122,17 @@ export class UlpObservabilityChartComponent implements OnChanges, OnInit {
     
     Object.entries({...this.datasets, ...this.threads}).forEach(entry => {
       let curveLabel = entry[0]
-      if(curveLabel !== this.totalLabel && curveLabel !== this.totalLabel+'_threads' && !(curveLabel.startsWith('spl_') && curveLabel.endsWith('_threads'))   ){
 
-        if(curveLabel.startsWith('spl_')){
+      const isNotTotalLabel = curveLabel !== this.totalLabel;
+      const isNotTotalThreadsLabel = curveLabel !== this.totalLabel + '_threads';
+      const hasSplPrefix = curveLabel.startsWith('spl_');
+      const hasThreadsSuffix = curveLabel.endsWith('_threads');
+      const isSplWithoutThreads = hasSplPrefix && !hasThreadsSuffix;
+      const isNotSplWithThreads = !hasSplPrefix && hasThreadsSuffix;
+
+      if(isNotTotalLabel && isNotTotalThreadsLabel && (isSplWithoutThreads || isNotSplWithThreads)){
+
+        if(hasSplPrefix){
           curveLabel = curveLabel.slice(curveLabel.indexOf('_')+1,curveLabel.length);
         }
         
@@ -133,7 +141,7 @@ export class UlpObservabilityChartComponent implements OnChanges, OnInit {
           this.data.datasets.push({
             label: curveLabel,
             data: [],
-            yAxisID: curveLabel.endsWith('_threads') ? 'y1' : 'y',
+            yAxisID: hasThreadsSuffix ? 'y1' : 'y',
           });
         }
   
@@ -141,7 +149,7 @@ export class UlpObservabilityChartComponent implements OnChanges, OnInit {
           if(dataset.label === curveLabel){
             entry[1].forEach(metric =>{
               dataset.data.push(metric);
-              dataset.hidden=this.visibleSamplers.includes(curveLabel) || curveLabel.endsWith('_threads')?false:true
+              dataset.hidden=this.visibleSamplers.includes(curveLabel) || hasThreadsSuffix?false:true
             })
             
           }


### PR DESCRIPTION
The metrics related to a groupThread is not shown any more on the graphs. This is fixed on the frontend side, by filtering the labels of curves to show on each chart. The metrics related to a Sample are prefixed by "spl_" and those related to threads are suffixed by "_threads". This means that we don't tolerate to show the labels that don't start with "spl_" and don't finish with "_thread". 

![config](https://user-images.githubusercontent.com/82438570/236486202-d1d0b1e1-aa79-4ede-9a40-02e104fe3956.png)

![graph](https://user-images.githubusercontent.com/82438570/236486231-3f9da900-b5e2-413d-a417-dea53aa2dcd0.png)
![stats_and_metrics](https://user-images.githubusercontent.com/82438570/236486242-fbfb5e84-79f1-4bbe-8757-1bd2a7b10b08.png)

