### PR TITLE
Formatting the totalLabel when its value is retrieved from the GUI

### DIFF
--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
@@ -224,7 +224,7 @@ public class ULPObservabilityListener extends AbstractTestElement
 	}
 
 	public String getTotalLabel() {
-		return getPropertyAsString(ULPODefaultConfig.TOTAL_LABEL_PROP, ULPODefaultConfig.totalLabel());
+		return Util.makeOpenMetricsName(getPropertyAsString(ULPODefaultConfig.TOTAL_LABEL_PROP, ULPODefaultConfig.totalLabel()));
 	}
 	
 	public String getRegex() {

--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/registry/MicrometerRegistry.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/registry/MicrometerRegistry.java
@@ -217,7 +217,7 @@ public class MicrometerRegistry {
 		Double totalThroughput = this.summaryRegistry.counter("count.total","sample",name).count() / (timeSinceFirstSampleCallInSeconds);
 		
 		return currentPeriodSummary == null ? null : new SampleLog(
-				Util.micrometerToOpenMetrics(name),
+				Util.makeOpenMetricsName(name),
 				timestamp,
 				// Current period data
 				(long) currentPeriodSummary.count(),

--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/util/Util.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/util/Util.java
@@ -58,17 +58,7 @@ public class Util {
     public static String makeMicrometerName(String name) {
     	return MATCH_PATTERN.matcher(name.trim().toLowerCase()).replaceAll(match -> micrometerDelimeter(match.group()));
     }
-    
-    /**
-     * Convert name from micrometer to OpenMetrics format
-     * 
-     * @param name Name to format
-     * @return Name in OpenMetrics format
-     */
-    public static String micrometerToOpenMetrics(String name) {
-    	return DELIMITER_PATTERN.matcher(name).replaceAll("_");
-    }
-    
+
     
     /**
      * Get sample response time


### PR DESCRIPTION
When the value of the totalLabel contains spaces, there were 2 problems noticed:
1. Server side : 
As the ``totalLabel`` retrieved from the GUI is different from the name of the sample which represents it, then this triggers a bug in the ``SampleLogger#guiLog()`` method. Indeed, this method builds the logs of all the samples in addition to the ``totalLabel``, except that the variable ``total`` (which represents the totalLabel) will always be null and a nullPointerException will be thrown at the penultimate line (before the return).

2. Front side :
``this.totalLabel`` sent from the servletConfig to the front is different from the name of the sample which represents the ``totalLabel``. So child components (charts, metrics) that depend on the ``totalLabel`` their treatments will not be correct. for example the metrics component relies on the ``totalLabel`` to retrieve the total values of the metrics, except that the ``totalLabel`` retrieved is different from the name of the sample which represents the ``totalLabel``.

Solution: the value of the totalLabel should be formatted  to the openMetric format once it is retreived from the GUI.
