### PR TITLE
Remove i18n from <mat-icon> tags

### DIFF
--- a/ulp-observability-front/src/main/front/src/app/components/ulp-observability-dashboard/ulp-observability-dashboard.component.html
+++ b/ulp-observability-front/src/main/front/src/app/components/ulp-observability-dashboard/ulp-observability-dashboard.component.html
@@ -8,12 +8,12 @@
     <div  [ngSwitch]="status">
 
         <div class="info" *ngSwitchCase="0">
-            <mat-icon class="icon" aria-hidden="false">{{'dashboard.settings' | translate}}</mat-icon>
+            <mat-icon class="icon" aria-hidden="false">settings</mat-icon>
             <span class="icon-align">{{'dashboard.config' | translate}}</span>
         </div>
 
         <div class="info" *ngSwitchCase="1">
-            <mat-icon class="icon" aria-hidden="false">{{'dashboard.pending' | translate}}</mat-icon>
+            <mat-icon class="icon" aria-hidden="false">pending</mat-icon>
             <span class="icon-align">{{'dashboard.waiting' | translate}}</span>
         </div>
 
@@ -22,7 +22,7 @@
             <form class="chart-form">
                 <mat-form-field class="form-full-width" appearance="fill">                   
                     <mat-label>
-                        <mat-icon>{{'dashboard.searchBar' | translate}}</mat-icon>
+                        <mat-icon>search</mat-icon>
                         {{'dashboard.graphFilter' | translate}}
                     </mat-label>
                     <input type="text" matInput [formControl]="control" [matAutocomplete]="auto">
@@ -67,12 +67,12 @@
         </div>
 
         <div class="info" *ngSwitchCase="3">
-            <mat-icon class="icon" aria-hidden="false"  >{{'dashboard.error' | translate}}</mat-icon>
+            <mat-icon class="icon" aria-hidden="false"  >error</mat-icon>
             <span class="icon-align"  >{{'dashboard.retryOnError' | translate}}</span>
         </div>
 
         <div class="info" *ngSwitchDefault>
-            <mat-icon class="icon" aria-hidden="false"  >{{'dashboard.help' | translate}}</mat-icon>
+            <mat-icon class="icon" aria-hidden="false"  >help</mat-icon>
             <span class="icon-align"  >{{'dashboard.unknownError' | translate}}</span>
         </div>
 
@@ -81,10 +81,10 @@
 
     <mat-card *ngIf="showErrorMessage" class="card-error">
         <mat-card-content>
-            <mat-icon aria-hidden="false" class="icon" >{{'dashboard.error' | translate}}</mat-icon>
+            <mat-icon aria-hidden="false" class="icon" >error</mat-icon>
             <span class="icon-align error-message"  >{{'dashboard.dataError' | translate}}</span>
             <mat-icon class="icon close-icon" aria-hidden="false" (click)="closeError()"  >
-                {{'dashboard.close' | translate}}
+                close
             </mat-icon>
         </mat-card-content>    
     </mat-card>

--- a/ulp-observability-front/src/main/front/src/assets/i18n/en.json
+++ b/ulp-observability-front/src/main/front/src/assets/i18n/en.json
@@ -1,17 +1,11 @@
 {
 	"dashboard": {
-        "settings": "settings",
 		"config" : "Retrieving plugin configuration",
-		"pending": "pending",
 		"waiting": "Waiting for sample metrics",
-		"searchBar": "search",
 		"graphFilter": "Graphs filters",
-		"error": "error",
 		"unknownError": "Something went wrong",
 		"retryOnError": "Startup error, retrying...",
-		"dataError": "Error on retrieving metrics data",
-		"help": "help",
-		"close": "close"
+		"dataError": "Error on retrieving metrics data"
     },
 	"charts": {
 		"average response times": "Average response time",

--- a/ulp-observability-front/src/main/front/src/assets/i18n/fr.json
+++ b/ulp-observability-front/src/main/front/src/assets/i18n/fr.json
@@ -1,17 +1,11 @@
 {
 	"dashboard": {
-        "settings": "paramètres",
 		"config" : "Récupération de la configuration du plugin",
-		"pending": "en attente",
 		"waiting": "En attente d'échantillons de métriques",
-		"searchBar": "recherche",
 		"graphFilter": "Filtrez les graphes",
-		"error": "erreur",
 		"unknownError": "Quelque chose s'est mal passé",
 		"retryOnError": "Erreur de démarrage, nouvelle tentative...",
-		"dataError": "Erreur lors de la récupération des données de métriques",
-		"help": "à l'aide",
-		"close": "fermer"
+		"dataError": "Erreur lors de la récupération des données de métriques"
     },
 	"charts": {
 		"average response times": "Temps de réponse moyen",


### PR DESCRIPTION
In a previous issue (#86), tags were moved to i18n resources. At the front, the ``<mat-icon>`` tag has also been internationalized when it shouldn't be. This causes CSS problems that destabilize the view when switching to French.

The value of the `mat-icon` tag is a predefined value and should therefore always be an English value. 