### PR TITLE
Checks the value of plugin properties before the test is run

### DIFF
--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
@@ -30,8 +30,8 @@ import com.ubikloadpack.jmeter.ulp.observability.log.SampleLogger;
 import com.ubikloadpack.jmeter.ulp.observability.metric.ResponseResult;
 import com.ubikloadpack.jmeter.ulp.observability.registry.MicrometerRegistry;
 import com.ubikloadpack.jmeter.ulp.observability.server.ULPObservabilityServer;
-import com.ubikloadpack.jmeter.ulp.observability.task.SampleMetricsLoggingTask;
 import com.ubikloadpack.jmeter.ulp.observability.task.MicrometerTask;
+import com.ubikloadpack.jmeter.ulp.observability.task.SampleMetricsLoggingTask;
 import com.ubikloadpack.jmeter.ulp.observability.util.Util;
 
 import io.timeandspace.cronscheduler.CronScheduler;
@@ -264,7 +264,7 @@ public class ULPObservabilityListener extends AbstractTestElement
 
 		listenerClientData.micrometerTaskList = new ArrayList<>();
 	}
-
+	
 	/**
 	 * Receives occurred samples and adds them to sample result queue if possible,
 	 * log buffer overflow exception otherwise
@@ -338,6 +338,8 @@ public class ULPObservabilityListener extends AbstractTestElement
 		LOG.info("Test started from host {}", host);
 
 		synchronized (LOCK) {
+			checkPropertyValues();
+			
 			// Init the Pattern regex object of the listener based on its saved String value.
 			String regexString = getRegex();
 			this.setRegex(regexString);
@@ -391,6 +393,13 @@ public class ULPObservabilityListener extends AbstractTestElement
 
 			instanceCount++;
 		}
+	}
+
+	private void checkPropertyValues() {
+		if (this.getLogFreq() < 1) {
+			this.setLogFreq(ULPODefaultConfig.logFrequency());
+		}
+		
 	}
 
 	private String computeUrl(Server server, String contextPath) {

--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
@@ -395,11 +395,24 @@ public class ULPObservabilityListener extends AbstractTestElement
 		}
 	}
 
+	
+	/**
+	 * Checks the value of the GUI properties. Checks that the properties 
+	 * that takes an integer as a value are all positives. The value of the 
+	 * percentiles are also checked. If an of the value is incorrect sets to its 
+	 * default value. The errors are logged while checking each value.
+	 */
 	private void checkPropertyValues() {
-		if (this.getLogFreq() < 1) {
-			this.setLogFreq(ULPODefaultConfig.logFrequency());
-		}
-		
+		this.setThreadSize(Util.validatePositiveNumeric(getThreadSize(), ULPODefaultConfig.threadSize(), "thread size"));
+		this.setBufferCapacity(Util.validatePositiveNumeric(getBufferCapacity(), ULPODefaultConfig.bufferCapacity(), "buffer capcity"));
+		this.setPct1(Util.validatePercentile(getPct1(), ULPODefaultConfig.pct1(), "percentile 1"));
+		this.setPct2(Util.validatePercentile(getPct2(), ULPODefaultConfig.pct2(), "percentile 2"));
+		this.setPct3( Util.validatePercentile(getPct3(), ULPODefaultConfig.pct3(), "percentile 3"));
+		this.setMicrometerExpiryTimeInSeconds(
+			String.valueOf(Util.validatePositiveNumeric(getMicrometerExpiryTimeInSecondsAsInt(), ULPODefaultConfig.micrometerExpiryTimeInSeconds(), "expiry time in seconds"))
+		);
+		this.setLogFreq(Util.validatePositiveNumeric(this.getLogFreq(), ULPODefaultConfig.logFrequency(), "log frequency"));
+		this.setTopErrors(Util.validatePositiveNumeric(getTopErrors(), ULPODefaultConfig.topErrors(), "number of top errors"));
 	}
 
 	private String computeUrl(Server server, String contextPath) {

--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/util/Util.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/util/Util.java
@@ -7,8 +7,8 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.report.utils.MetricUtils;
-import org.apache.jmeter.samplers.SampleSaveConfiguration;
-import org.apache.jmeter.util.JMeterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Set of static utility methods
@@ -17,9 +17,9 @@ import org.apache.jmeter.util.JMeterUtils;
  *
  */
 public class Util {
-	
+	private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+
 	private static final Pattern MATCH_PATTERN = Pattern.compile("[^a-zA-Z0-9]");
-	private static final Pattern DELIMITER_PATTERN = Pattern.compile("[.]");
 	private static final Set<String> DELIMITERS = new HashSet<>(Arrays.asList("_",".", "-", " "));	
 	
 	/** 
@@ -95,5 +95,38 @@ public class Util {
          }
          return key;
     }
+    
+
+    /**
+     * Check whether the value of the percentile is included in [0, 100].
+	 * If yes, then returns it. Otherwise, return the default value.
+     * @param pct The percentile to check.
+     * @param defaultValue the default value to return if the check fails.
+     * @param parameter this is used to log the name of the parameter when the checking fails.
+     * @return Either the given percentile or the default value.
+     */
+	public static int validatePercentile(int pct, int defaultValue, String parameter) {	
+		if(pct > 100 || pct < 0) {
+			LOG.error("{} must contain only values between 0 and 100. Found {}", parameter, pct);
+			return defaultValue;
+		}
+		return pct;
+	}
+	
+	/**
+	 * Checks whether the given value is positive or not. If yes, then returns it. Otherwise,
+	 * return the default value.
+	 * @param value The value to check
+	 * @param defaultValue the default value to return if the check fails.
+	 * @param parameter this is used to log the name of the parameter when the checking fails.
+	 * @return Either the given value or the default value.
+	 */
+	public static int validatePositiveNumeric(int value, int defaultValue, String parameter) {
+		if(value < 1) {
+			LOG.error("{} must be greater than 0", parameter);
+			return defaultValue;
+		}
+		return value;
+	}
 	    
 }

--- a/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/AbstractConfigTest.java
+++ b/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/AbstractConfigTest.java
@@ -21,8 +21,6 @@ import java.util.stream.Collectors;
 import org.apache.jmeter.util.JMeterUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import com.ubikloadpack.jmeter.ulp.observability.listener.ULPObservabilityListener;
 

--- a/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/AbstractConfigTest.java
+++ b/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/AbstractConfigTest.java
@@ -42,6 +42,8 @@ public abstract class AbstractConfigTest {
 	public void setUp() throws Exception {
 		this.endpoint = new URL("http://" + HOST + ":" + PORT);
 		
+		this.setJmeterProperties();
+		
 		listener = new ULPObservabilityListener();
 		listener.setJettyPort(PORT);
 		listener.setMetricsRoute(METRICS_ROUTE);
@@ -55,12 +57,22 @@ public abstract class AbstractConfigTest {
 		listener.setLogFreq(LOG_FREQUENCY);
 		listener.setTopErrors(TOP_ERRORS);
 		listener.setTotalLabel(TOTAL_LABEL);
+		
 		this.testStarted(HOST);
 	}
 	
 	@AfterEach
 	public void tearDown() throws Exception {
         listener.testEnded(HOST);
+	}
+	
+	/**
+	 * Should be invoked before testStarted() method
+	 */
+	private void setJmeterProperties() {
+		URL url = this.getClass().getClassLoader().getResource("jmeter.properties");
+		JMeterUtils.loadJMeterProperties(url.getPath());
+		JMeterUtils.setLocale(Locale.ENGLISH);
 	}
 	
 	/**
@@ -126,11 +138,7 @@ public abstract class AbstractConfigTest {
 	}
 	
 	protected void testStarted(String host) {
-		try (MockedStatic<JMeterUtils> utilitites = Mockito.mockStatic(JMeterUtils.class)) {
-			utilitites.when(() -> JMeterUtils.getLocale()).thenReturn(new Locale(Locale.ENGLISH.getLanguage()));
-			
-			listener.testStarted(host);
-		} 
+		listener.testStarted(host);
 	}
 	
 	protected void assertHttpContentTypeAndResponseStatus(HttpResponse httpResponse, int expectedStatus, String expectedContentType) {

--- a/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/ULPObservabilityConfigServletTest.java
+++ b/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/ULPObservabilityConfigServletTest.java
@@ -38,6 +38,22 @@ public class ULPObservabilityConfigServletTest extends AbstractConfigTest {
         assertEquals(expectedConfig, actualConfig);
 	}
 	
+	@Test
+	@DisplayName("when logFrequency is zero expect 30 second as default value")
+	public void whenLogFrequencyIsZeroExpectDefaultValue() throws Exception {
+		this.listener.testEnded(HOST); // should stop the listener started by @BeforeEach before setting the totalLabel property
+		this.listener.setLogFreq(0); 
+		this.testStarted(HOST); // restart the listener 
+		
+		HttpResponse httpResponse = this.sendGetRequest("/config");
+		assertHttpContentTypeAndResponseStatus(httpResponse, HttpStatus.OK_200, "application/json");
+	    
+	    String actualConfig = httpResponse.getResponse();
+        String expectedConfig = getExpectedConfigAsJson(METRICS_ROUTE, 30, TOP_ERRORS, TOTAL_LABEL); 
+        
+        assertEquals(expectedConfig, actualConfig);
+	}
+	
 	private String getExpectedConfigAsJson(String metricsRoute, int logFrequency, int topErrors, String totalLabel) {
 		return String.format("{\"metricsRoute\":\"%s\",\"logFrequency\":%s,\"topErrors\":%s,\"totalLabel\":\"%s\",\"localeLang\":\"en\"}",
 				metricsRoute, logFrequency, topErrors, totalLabel);

--- a/back/src/test/resources/jmeter.properties
+++ b/back/src/test/resources/jmeter.properties
@@ -1,0 +1,1 @@
+ULPObservability.LogFrequency=30


### PR DESCRIPTION
I've added a method that checks property values in the same way as the GUI. The method is invoked as the first statement in the ULPObservabilityListener#testStarted() function. The method sets property values to their default values when these are not correct.

There's an integration test in the PR that tests a special case. When the value of the logFrequency property is zero, we should expect the listener to change it to its default value (30 seconds). 