### PR TITLE
Use BlokingQueue#offer(E e) instead of BlokingQueue#offer(E e, long timeout, TimeUnit unit)

### DIFF
--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
@@ -288,15 +288,17 @@ public class ULPObservabilityListener extends AbstractTestElement
 							sample.getGroupThreads(), sample.getAllThreads(), sample.getSampleLabel(), sample.getStartTime(),
 							sample.getEndTime());
 					if (!listenerClientData.sampleQueue.offer(responseResult)) { 
-						LOG.warn("Sample queue overflow. The currens size of the queue is {}.", listenerClientData.sampleQueue.size());
+						LOG.warn("Sample queue overflow. The current size of the queue is {}.", listenerClientData.sampleQueue.size());
 						// if the queue is full, should try to insert the element until the space is available
-						listenerClientData.sampleQueue.put(responseResult);							
+						long t1 = System.nanoTime();
+						listenerClientData.sampleQueue.put(responseResult);
+						LOG.warn("Waited {} nanos to put ResponseResult in queue, you may need to increase size of the queue", System.nanoTime()-t1);
 					}
 				}
 				
 			}  catch (Exception e) {
-				LOG.warn("Thread interrupted while adding sample `" + sampleEvent.getResult().getSampleLabel(true) + "` to the queue."
-						+ " Sample not added to queue.");
+				LOG.warn("Thread interrupted while adding sample '{}' to the queue. Sample not added to queue.",
+				        sampleEvent.getResult().getSampleLabel(true));
 			}
 		}
 	}

--- a/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
+++ b/back/src/main/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListener.java
@@ -283,16 +283,20 @@ public class ULPObservabilityListener extends AbstractTestElement
 				}
 					
 				if(isStringMatchingRegex(sampleLabel)) {
-					if (!listenerClientData.sampleQueue.offer(new ResponseResult(sampleEvent.getThreadGroup(),
+					ResponseResult responseResult = new ResponseResult(sampleEvent.getThreadGroup(),
 							Util.getResponseTime(sample.getEndTime(), sample.getStartTime()), hasError, errorCode,
 							sample.getGroupThreads(), sample.getAllThreads(), sample.getSampleLabel(), sample.getStartTime(),
-							sample.getEndTime()), 1000, TimeUnit.MILLISECONDS)) {
-						LOG.error("Sample queue overflow. Sample dropped: {}", sampleEvent.getThreadGroup());
+							sample.getEndTime());
+					if (!listenerClientData.sampleQueue.offer(responseResult)) { 
+						LOG.warn("Sample queue overflow. The currens size of the queue is {}.", listenerClientData.sampleQueue.size());
+						// if the queue is full, should try to insert the element until the space is available
+						listenerClientData.sampleQueue.put(responseResult);							
 					}
 				}
 				
-			} catch (InterruptedException e) {
-				LOG.warn("Thread interrupted while adding sample `" + sampleEvent.getResult().getThreadName() + "` to the queue. Data associated with the sample are not recorded.");
+			}  catch (Exception e) {
+				LOG.warn("Thread interrupted while adding sample `" + sampleEvent.getResult().getSampleLabel(true) + "` to the queue."
+						+ " Sample not added to queue.");
 			}
 		}
 	}

--- a/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListenerTest.java
+++ b/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListenerTest.java
@@ -14,7 +14,7 @@ import com.ubikloadpack.jmeter.ulp.observability.server.AbstractConfigTest;
 public class ULPObservabilityListenerTest extends AbstractConfigTest {	
 
 	@Test
-	@DisplayName("When a sample event occurs and the current thread is interrupted, expect the sample result is added to the queue")
+	@DisplayName("When a sample event occurs and the current thread is interrupted, expect the sample result to be added to the queue")
 	void whenASampleEventOccursAndTheCurrentThreadIsInterruptedExpectTheSampleResultIsAddedToTheQueue() throws InterruptedException {		
 	    SampleResult sampleResult = mock(SampleResult.class);
 	    when(sampleResult.getSampleLabel()).thenReturn("sampleTest");

--- a/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListenerTest.java
+++ b/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/listener/ULPObservabilityListenerTest.java
@@ -1,0 +1,40 @@
+package com.ubikloadpack.jmeter.ulp.observability.listener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.jmeter.samplers.SampleEvent;
+import org.apache.jmeter.samplers.SampleResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ubikloadpack.jmeter.ulp.observability.server.AbstractConfigTest;
+
+public class ULPObservabilityListenerTest extends AbstractConfigTest {	
+
+	@Test
+	@DisplayName("When a sample event occurs and the current thread is interrupted, expect the sample result is added to the queue")
+	void whenASampleEventOccursAndTheCurrentThreadIsInterruptedExpectTheSampleResultIsAddedToTheQueue() throws InterruptedException {		
+	    SampleResult sampleResult = mock(SampleResult.class);
+	    when(sampleResult.getSampleLabel()).thenReturn("sampleTest");
+
+	    SampleEvent sampleEvent = mock(SampleEvent.class);
+	    when(sampleEvent.getThreadGroup()).thenReturn("group1");
+	    when(sampleEvent.getResult()).thenReturn(sampleResult);
+
+	    assertEquals(0, listener.getSampleQueue().size()); // assert sample is empty before adding a sample
+
+        // Interrupt the current thread to simulate an interruption
+        Thread.currentThread().interrupt();
+
+        // Invoke sampleOccured
+        listener.sampleOccurred(sampleEvent);
+
+        // Check that the sample has been added to the queue despite thread interruption
+	    assertEquals(1, listener.getSampleQueue().size());     
+
+	    Thread.interrupted();
+	}
+
+}

--- a/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/AbstractConfigTest.java
+++ b/back/src/test/java/com/ubikloadpack/jmeter/ulp/observability/server/AbstractConfigTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractConfigTest {
 		listener.setPct1(50);
 		listener.setPct2(90);
 		listener.setPct3(95);
-		listener.setThreadSize(5);
+		listener.setThreadSize(1);
 		listener.setBufferCapacity(30000);
 		listener.setMicrometerExpiryTimeInSeconds("3600");
 		listener.setLogFreq(LOG_FREQUENCY);
@@ -60,7 +60,7 @@ public abstract class AbstractConfigTest {
 	}
 	
 	@AfterEach
-	public void tearDown() throws Exception {
+	public void tearDown() {
         listener.testEnded(HOST);
 	}
 	


### PR DESCRIPTION
I added an integration test to validate that the old solution doesn't push data when the thread is interrupted. I added this test :

```java
@Test
@DisplayName("When a sample event occurs and the current thread is interrupted, expect the sample result is added to the queue")
void whenASampleEventOccursAndTheCurrentThreadIsInterruptedExpectTheSampleResultIsAddedToTheQueue() throws InterruptedException {		
      SampleResult sampleResult = mock(SampleResult.class);
      when(sampleResult.getSampleLabel()).thenReturn("sampleTest");
      
      SampleEvent sampleEvent = mock(SampleEvent.class);
      when(sampleEvent.getThreadGroup()).thenReturn("group1");
      when(sampleEvent.getResult()).thenReturn(sampleResult);
      
      assertEquals(0, listener.getSampleQueue().size()); // assert sample is empty before adding a sample
	  
      // Interrupt the current thread to simulate an interruption
      Thread.currentThread().interrupt();

      // Invoke sampleOccured
      listener.sampleOccurred(sampleEvent);
      
      // Check that the sample has been added to the queue despite thread interruption
      assertEquals(1, listener.getSampleQueue().size());     
      
      Thread.interrupted();
}
```

This test fails when using the ``BlockingQueue#offer(E e, long timeout, TimeUnit unit)``, because the the second assertion fails (the size of the queue was 0). But when i changed to the method ``BlockingQueue#offer(E e)`` the test successes. 